### PR TITLE
Fixed use of `ENV` in CMake `if`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,7 @@ Enhancements:
 - #7361 Re-implement packaging for GitHub workflows (Linux)
 - #7363 Schedule CI daily at 5am to detect code rot early
 - #7364 Format all source with Clang and introduce lint workflow
+- #7366 Fixed use of ENV in CMake if
 
 # 1.14.6
 

--- a/cmake/Definitions.cmake
+++ b/cmake/Definitions.cmake
@@ -30,7 +30,7 @@ macro(configure_definitions)
     add_definitions(-DSYNERGY_ENABLE_LICENSING=1)
   else()
     set(PRODUCT_NAME "Synergy 1 Community Edition")
-    if(DEFINED ENV{SYNERGY_PRODUCT_NAME})
+    if(NOT "$ENV{SYNERGY_PRODUCT_NAME}" STREQUAL "")
       set(PRODUCT_NAME $ENV{SYNERGY_PRODUCT_NAME})
     endif()
     message(STATUS "Product name: ${PRODUCT_NAME}")
@@ -87,24 +87,24 @@ macro(configure_options)
   # licensing is off by default to make life easier for contributors.
   set(DEFAULT_ENABLE_LICENSING OFF)
 
-  if(DEFINED ENV{SYNERGY_BUILD_MINIMAL})
+  if("$ENV{SYNERGY_BUILD_MINIMAL}" STREQUAL "true")
     set(DEFAULT_BUILD_GUI OFF)
     set(DEFAULT_BUILD_INSTALLER OFF)
   endif()
 
-  if(DEFINED ENV{SYNERGY_NO_TESTS})
+  if("$ENV{SYNERGY_BUILD_TESTS}" STREQUAL "false")
     set(DEFAULT_BUILD_TESTS OFF)
   endif()
 
-  if(DEFINED ENV{SYNERGY_BUILD_UNIFIED})
+  if("$ENV{SYNERGY_BUILD_UNIFIED}" STREQUAL "true")
     set(DEFAULT_BUILD_UNIFIED ON)
   endif()
 
-  if(DEFINED ENV{SYNERGY_ENABLE_LICENSING})
+  if("$ENV{SYNERGY_ENABLE_LICENSING}" STREQUAL "true")
     set(DEFAULT_ENABLE_LICENSING ON)
   endif()
 
-  if(DEFINED ENV{SYNERGY_ENABLE_COVERAGE})
+  if("$ENV{SYNERGY_ENABLE_COVERAGE}" STREQUAL "true")
     set(DEFAULT_ENABLE_COVERAGE ON)
   endif()
 

--- a/cmake/Definitions.cmake
+++ b/cmake/Definitions.cmake
@@ -22,19 +22,19 @@ macro(configure_definitions)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
-  set(PRODUCT_NAME "Synergy 1 Community Edition")
-  if(DEFINED $ENV{SYNERGY_PRODUCT_NAME})
-    message(STATUS "Product name: $ENV{SYNERGY_PRODUCT_NAME}")
-    set(PRODUCT_NAME $ENV{SYNERGY_PRODUCT_NAME})
-  endif()
-  add_definitions(-DSYNERGY_PRODUCT_NAME="${PRODUCT_NAME}")
-
   configure_ninja()
   configure_options()
 
   if(ENABLE_LICENSING)
     message(STATUS "Licensing enabled")
     add_definitions(-DSYNERGY_ENABLE_LICENSING=1)
+  else()
+    set(PRODUCT_NAME "Synergy 1 Community Edition")
+    if(DEFINED ENV{SYNERGY_PRODUCT_NAME})
+      set(PRODUCT_NAME $ENV{SYNERGY_PRODUCT_NAME})
+    endif()
+    message(STATUS "Product name: ${PRODUCT_NAME}")
+    add_definitions(-DSYNERGY_PRODUCT_NAME="${PRODUCT_NAME}")
   endif()
 
   if(ENABLE_AUTO_CONFIG)
@@ -87,24 +87,24 @@ macro(configure_options)
   # licensing is off by default to make life easier for contributors.
   set(DEFAULT_ENABLE_LICENSING OFF)
 
-  if(DEFINED $ENV{SYNERGY_BUILD_MINIMAL})
+  if(DEFINED ENV{SYNERGY_BUILD_MINIMAL})
     set(DEFAULT_BUILD_GUI OFF)
     set(DEFAULT_BUILD_INSTALLER OFF)
   endif()
 
-  if(DEFINED $ENV{SYNERGY_NO_TESTS})
+  if(DEFINED ENV{SYNERGY_NO_TESTS})
     set(DEFAULT_BUILD_TESTS OFF)
   endif()
 
-  if(DEFINED $ENV{SYNERGY_BUILD_UNIFIED})
+  if(DEFINED ENV{SYNERGY_BUILD_UNIFIED})
     set(DEFAULT_BUILD_UNIFIED ON)
   endif()
 
-  if(DEFINED $ENV{SYNERGY_ENABLE_LICENSING})
+  if(DEFINED ENV{SYNERGY_ENABLE_LICENSING})
     set(DEFAULT_ENABLE_LICENSING ON)
   endif()
 
-  if(DEFINED $ENV{SYNERGY_ENABLE_COVERAGE})
+  if(DEFINED ENV{SYNERGY_ENABLE_COVERAGE})
     set(DEFAULT_ENABLE_COVERAGE ON)
   endif()
 


### PR DESCRIPTION
Upstream: https://github.com/symless/synergy-core/pull/7366